### PR TITLE
Size reduction and compatibility changes

### DIFF
--- a/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/cl_init.lua
+++ b/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/cl_init.lua
@@ -49,6 +49,15 @@ net.Receive("TotalStatistics_PlayerStatsMessage", function()
 	PlayerStats = util.JSONToTable(playerStatsJson)
 end)
 
+local function GetRoleRate(record, role)
+	local wins = TotalStats.GetValue(record, role .. "Wins")
+	local rounds = math.max(wins, TotalStats.GetValue(record, role .. "Rounds", 1))
+	if rounds > 0 then
+		return wins/rounds*100
+	end
+	return 1
+end
+
 local function DisplayWindow()
 
 	GetPlayerData()
@@ -151,9 +160,9 @@ local function DisplayWindow()
 			DescriptionLabel:SetText("Average role win rate (%).")
 			for id, record in pairs(PlayerStats) do
 				if(id==LocalPlayer():SteamID()) then
-					DataDisplay:AddLine("Detective", math.Round(TotalStats.GetValue(record, "DetectiveWins")/TotalStats.GetValue(record, "DetectiveRounds")*100), 1)
-					DataDisplay:AddLine("Innocent", math.Round(TotalStats.GetValue(record, "InnocentWins")/TotalStats.GetValue(record, "InnocentRounds")*100), 1)
-					DataDisplay:AddLine("Traitor", math.Round(TotalStats.GetValue(record, "TraitorWins")/TotalStats.GetValue(record, "TraitorRounds")*100), 1)
+					DataDisplay:AddLine("Detective", math.Round(GetRoleRate(record, "Detective"), 1))
+					DataDisplay:AddLine("Innocent", math.Round(GetRoleRate(record, "Innocent"), 1))
+					DataDisplay:AddLine("Traitor", math.Round(GetRoleRate(record, "Traitor"), 1))
 				end
 			end
 			if(CustomRolesEnabled) then
@@ -161,8 +170,8 @@ local function DisplayWindow()
 					if(id==LocalPlayer():SteamID()) then
 						for r = 0, ROLE_MAX do
 							rolestring = ROLE_STRINGS[r]
-							rolestring_cap = rolestring:sub(1, 1):upper() .. rolestring:sub(2)
-							DataDisplay:AddLine(rolestring_cap, math.Round(TotalStats.GetValue(record, rolestring.."Wins")/TotalStats.GetValue(record, rolestring.."Rounds", 1)*100), 1)
+							rolestring_cap = string.Capitalize(rolestring)
+							DataDisplay:AddLine(rolestring_cap, math.Round(GetRoleRate(record, rolestring), 1))
 						end
 					end
 				end
@@ -270,10 +279,10 @@ local function DisplayWindow()
 			local AvgDRate = 0
 			local AvgIRate = 0
 			local AvgTRate = 0
-			for id, record in pairs(PlayerStats) do
-				AvgDRate = AvgDRate + (TotalStats.GetValue(record, "DetectiveWins")/TotalStats.GetValue(record, "DetectiveRounds")*100)
-				AvgIRate = AvgIRate + (TotalStats.GetValue(record, "InnocentWins")/TotalStats.GetValue(record, "InnocentRounds")*100)
-				AvgTRate = AvgTRate + (TotalStats.GetValue(record, "TraitorWins")/TotalStats.GetValue(record, "TraitorRounds")*100)
+			for _, record in pairs(PlayerStats) do
+				AvgDRate = AvgDRate + GetRoleRate(record, "Detective")
+				AvgIRate = AvgIRate + GetRoleRate(record, "Innocent")
+				AvgTRate = AvgTRate + GetRoleRate(record, "Traitor")
 			end
 			AvgDRate = math.Round(AvgDRate / table.Count(PlayerStats), 1)
 			AvgIRate = math.Round(AvgIRate / table.Count(PlayerStats), 1)
@@ -288,11 +297,10 @@ local function DisplayWindow()
 				for r = 3, ROLE_MAX do
 					sRolestring = ROLE_STRINGS_SHORT[r]
 					rolestring = ROLE_STRINGS[r]
-					rolestring_cap = rolestring:sub(1, 1):upper() .. rolestring:sub(2)
+					rolestring_cap = string.Capitalize(rolestring)
 					AvgRate[sRolestring] = 0
 					for id, record in pairs(PlayerStats) do
-						AvgRate[sRolestring] = AvgRate[sRolestring] +
-								(TotalStats.GetValue(record, rolestring.."Wins")/TotalStats.GetValue(record, rolestring.."Rounds", 1)*100)
+						AvgRate[sRolestring] = AvgRate[sRolestring] + GetRoleRate(record, rolestring)
 					end
 					AvgRate[sRolestring] = math.Round(AvgRate[sRolestring] / table.Count(PlayerStats), 1)
 					DataDisplay:AddLine(rolestring_cap, AvgRate[sRolestring])

--- a/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/cl_init.lua
+++ b/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/cl_init.lua
@@ -49,17 +49,6 @@ net.Receive("TotalStatistics_PlayerStatsMessage", function()
 	PlayerStats = util.JSONToTable(playerStatsJson)
 end)
 
-local function LowerFirst(str)
-	local first = str:sub(1, 1):lower()
-	local rest = str:sub(2)
-	return first .. rest
-end
-
-local function GetValue(record, name, default)
-	if not default then default = 0 end
-	return record[name] or record[LowerFirst(name)] or default
-end
-
 local function DisplayWindow()
 
 	GetPlayerData()
@@ -132,7 +121,7 @@ local function DisplayWindow()
 			rolestring_cap = rolestring:sub(1, 1):upper() .. rolestring:sub(2)
 			if str == rolestring_cap then
 				for id, record in pairs(PlayerStats) do
-					DataDisplay:AddLine(GetValue(record, "Nickname", "<UNKNOWN>"), math.Round(GetValue(record, rolestring.."Wins")/GetValue(record, rolestring.."Rounds", 1)*100, 1))
+					DataDisplay:AddLine(TotalStats.GetValue(record, "Nickname", "<UNKNOWN>"), math.Round(TotalStats.GetValue(record, rolestring.."Wins")/TotalStats.GetValue(record, rolestring.."Rounds", 1)*100, 1))
 					DataDisplay:SortByColumn(2, true)
 				end
 			end
@@ -162,9 +151,9 @@ local function DisplayWindow()
 			DescriptionLabel:SetText("Average role win rate (%).")
 			for id, record in pairs(PlayerStats) do
 				if(id==LocalPlayer():SteamID()) then
-					DataDisplay:AddLine("Detective", math.Round(GetValue(record, "DetectiveWins")/GetValue(record, "DetectiveRounds")*100), 1)
-					DataDisplay:AddLine("Innocent", math.Round(GetValue(record, "InnocentWins")/GetValue(record, "InnocentRounds")*100), 1)
-					DataDisplay:AddLine("Traitor", math.Round(GetValue(record, "TraitorWins")/GetValue(record, "TraitorRounds")*100), 1)
+					DataDisplay:AddLine("Detective", math.Round(TotalStats.GetValue(record, "DetectiveWins")/TotalStats.GetValue(record, "DetectiveRounds")*100), 1)
+					DataDisplay:AddLine("Innocent", math.Round(TotalStats.GetValue(record, "InnocentWins")/TotalStats.GetValue(record, "InnocentRounds")*100), 1)
+					DataDisplay:AddLine("Traitor", math.Round(TotalStats.GetValue(record, "TraitorWins")/TotalStats.GetValue(record, "TraitorRounds")*100), 1)
 				end
 			end
 			if(CustomRolesEnabled) then
@@ -173,7 +162,7 @@ local function DisplayWindow()
 						for r = 0, ROLE_MAX do
 							rolestring = ROLE_STRINGS[r]
 							rolestring_cap = rolestring:sub(1, 1):upper() .. rolestring:sub(2)
-							DataDisplay:AddLine(rolestring_cap, math.Round(GetValue(record, rolestring.."Wins")/GetValue(record, rolestring.."Rounds", 1)*100), 1)
+							DataDisplay:AddLine(rolestring_cap, math.Round(TotalStats.GetValue(record, rolestring.."Wins")/TotalStats.GetValue(record, rolestring.."Rounds", 1)*100), 1)
 						end
 					end
 				end
@@ -183,9 +172,9 @@ local function DisplayWindow()
 		DescriptionLabel:SetText("Rounds playing each role (times role played/total rounds played).")
 			for id, record in pairs(PlayerStats) do
 				if(id==LocalPlayer():SteamID()) then
-					DataDisplay:AddLine("Detective", GetValue(record, "DetectiveRounds").."/"..GetValue(record, "TotalRoundsPlayed"))
-					DataDisplay:AddLine("Innocent", GetValue(record, "InnocentRounds").."/"..GetValue(record, "TotalRoundsPlayed"))
-					DataDisplay:AddLine("Traitor", GetValue(record, "TraitorRounds").."/"..GetValue(record, "TotalRoundsPlayed"))
+					DataDisplay:AddLine("Detective", TotalStats.GetValue(record, "DetectiveRounds").."/"..TotalStats.GetValue(record, "TotalRoundsPlayed"))
+					DataDisplay:AddLine("Innocent", TotalStats.GetValue(record, "InnocentRounds").."/"..TotalStats.GetValue(record, "TotalRoundsPlayed"))
+					DataDisplay:AddLine("Traitor", TotalStats.GetValue(record, "TraitorRounds").."/"..TotalStats.GetValue(record, "TotalRoundsPlayed"))
 				end
 			end
 			if(CustomRolesEnabled) then
@@ -195,7 +184,7 @@ local function DisplayWindow()
 							for r = 3, ROLE_MAX do
 								rolestring = ROLE_STRINGS[r]
 								rolestring_cap = rolestring:sub(1, 1):upper() .. rolestring:sub(2)
-								DataDisplay:AddLine(rolestring_cap, (GetValue(record, rolestring.."Rounds")).."/"..GetValue(record, "TotalRoundsPlayed"))
+								DataDisplay:AddLine(rolestring_cap, (TotalStats.GetValue(record, rolestring.."Rounds")).."/"..TotalStats.GetValue(record, "TotalRoundsPlayed"))
 							end
 						end
 					end
@@ -206,7 +195,7 @@ local function DisplayWindow()
 			DescriptionLabel:SetText("Win rate when on a traitor team with each player (%).")
 
 			local record = PlayerStats[LocalPlayer():SteamID()]
-			local partners = GetValue(record, "TraitorPartners", nil)
+			local partners = TotalStats.GetValue(record, "TraitorPartners", nil)
 			if (partners==nil) then
 				DataDisplay:AddLine("No partners yet", "No partners yet")
 			else
@@ -220,7 +209,7 @@ local function DisplayWindow()
 			DescriptionLabel:SetText("Times you've bought each detective item")
 
 			local record = PlayerStats[LocalPlayer():SteamID()]
-			local equip = GetValue(record, "DetectiveEquipment", nil)
+			local equip = TotalStats.GetValue(record, "DetectiveEquipment", nil)
 			if (equip==nil) then
 				DataDisplay:AddLine("No equipment yet", "No equipment yet")
 			else
@@ -234,7 +223,7 @@ local function DisplayWindow()
 			DescriptionLabel:SetText("Times you've bought each traitor item")
 
 			local record = PlayerStats[LocalPlayer():SteamID()]
-			local equip = GetValue(record, "TraitorEquipment", nil)
+			local equip = TotalStats.GetValue(record, "TraitorEquipment", nil)
 			if (equip==nil) then
 				DataDisplay:AddLine("No equipment yet", "No equipment yet")
 			else
@@ -282,9 +271,9 @@ local function DisplayWindow()
 			local AvgIRate = 0
 			local AvgTRate = 0
 			for id, record in pairs(PlayerStats) do
-				AvgDRate = AvgDRate + (GetValue(record, "DetectiveWins")/GetValue(record, "DetectiveRounds")*100)
-				AvgIRate = AvgIRate + (GetValue(record, "InnocentWins")/GetValue(record, "InnocentRounds")*100)
-				AvgTRate = AvgTRate + (GetValue(record, "TraitorWins")/GetValue(record, "TraitorRounds")*100)
+				AvgDRate = AvgDRate + (TotalStats.GetValue(record, "DetectiveWins")/TotalStats.GetValue(record, "DetectiveRounds")*100)
+				AvgIRate = AvgIRate + (TotalStats.GetValue(record, "InnocentWins")/TotalStats.GetValue(record, "InnocentRounds")*100)
+				AvgTRate = AvgTRate + (TotalStats.GetValue(record, "TraitorWins")/TotalStats.GetValue(record, "TraitorRounds")*100)
 			end
 			AvgDRate = math.Round(AvgDRate / table.Count(PlayerStats), 1)
 			AvgIRate = math.Round(AvgIRate / table.Count(PlayerStats), 1)
@@ -303,7 +292,7 @@ local function DisplayWindow()
 					AvgRate[sRolestring] = 0
 					for id, record in pairs(PlayerStats) do
 						AvgRate[sRolestring] = AvgRate[sRolestring] +
-								(GetValue(record, rolestring.."Wins")/GetValue(record, rolestring.."Rounds", 1)*100)
+								(TotalStats.GetValue(record, rolestring.."Wins")/TotalStats.GetValue(record, rolestring.."Rounds", 1)*100)
 					end
 					AvgRate[sRolestring] = math.Round(AvgRate[sRolestring] / table.Count(PlayerStats), 1)
 					DataDisplay:AddLine(rolestring_cap, AvgRate[sRolestring])
@@ -318,36 +307,36 @@ local function DisplayWindow()
 		elseif str == "Most rounds played" then
 			DescriptionLabel:SetText("Total number of rounds played.")
 			for id, record in pairs(PlayerStats) do
-				DataDisplay:AddLine(GetValue(record, "Nickname", "<UNKNOWN>"), GetValue(record, "TotalRoundsPlayed"))
+				DataDisplay:AddLine(TotalStats.GetValue(record, "Nickname", "<UNKNOWN>"), TotalStats.GetValue(record, "TotalRoundsPlayed"))
 				DataDisplay:SortByColumn(2, true)
 			end
 
 		elseif str == "Most often killed first" then
 			DescriptionLabel:SetText("Percentage of their rounds that each player is killed first (%).")
 			for id, record in pairs(PlayerStats) do
-				DataDisplay:AddLine(GetValue(record, "Nickname", "<UNKNOWN>"), math.Round(GetValue(record, "KilledFirst") / GetValue(record, "TotalRoundsPlayed") * 100, 2))
+				DataDisplay:AddLine(TotalStats.GetValue(record, "Nickname", "<UNKNOWN>"), math.Round(TotalStats.GetValue(record, "KilledFirst") / TotalStats.GetValue(record, "TotalRoundsPlayed") * 100, 2))
 				DataDisplay:SortByColumn(2, true)
 			end
 
 		elseif str == "Most crooked cop" then
 			DescriptionLabel:SetText("Average number of innocents killed per round as detective.")
 			for id, record in pairs(PlayerStats) do
-				DataDisplay:AddLine(GetValue(record, "Nickname", "<UNKNOWN>"), math.Round(GetValue(record, "CrookedCop") / GetValue(record, "DetectiveRounds"), 2))
+				DataDisplay:AddLine(TotalStats.GetValue(record, "Nickname", "<UNKNOWN>"), math.Round(TotalStats.GetValue(record, "CrookedCop") / TotalStats.GetValue(record, "DetectiveRounds"), 2))
 				DataDisplay:SortByColumn(2, true)
 			end
 
 		elseif str == "Most trigger-happy innocent" then
 			DescriptionLabel:SetText("Average number of innocent players killed while on the innocent team.")
 			for id, record in pairs(PlayerStats) do
-				DataDisplay:AddLine(GetValue(record, "Nickname", "<UNKNOWN>"), math.Round(GetValue(record, "TriggerHappyInnocent")/
-				(GetValue(record, "InnocentRounds", 1) + GetValue(record, "MercenaryRounds") + GetValue(record, "GlitchRounds") + GetValue(record, "PhantomRounds")), 2))
+				DataDisplay:AddLine(TotalStats.GetValue(record, "Nickname", "<UNKNOWN>"), math.Round(TotalStats.GetValue(record, "TriggerHappyInnocent")/
+				(TotalStats.GetValue(record, "InnocentRounds", 1) + TotalStats.GetValue(record, "MercenaryRounds") + TotalStats.GetValue(record, "GlitchRounds") + TotalStats.GetValue(record, "PhantomRounds")), 2))
 				DataDisplay:SortByColumn(2, true)
 			end
 
 		elseif str == "Least safe near ledges" then
 			DescriptionLabel:SetText("Total fall damage taken.")
 			for id, record in pairs(PlayerStats) do
-				DataDisplay:AddLine(GetValue(record, "Nickname", "<UNKNOWN>"), GetValue(record, "TotalFallDamage"))
+				DataDisplay:AddLine(TotalStats.GetValue(record, "Nickname", "<UNKNOWN>"), TotalStats.GetValue(record, "TotalFallDamage"))
 				DataDisplay:SortByColumn(2, true)
 			end
 
@@ -357,14 +346,14 @@ local function DisplayWindow()
 			for id, record in pairs(PlayerStats) do
 				local bestPartner = {Nick = "No traitor partners yet", Winrate = -1}
 				local thisPartnerWinRate = -1
-				for partnerID, partnerTable in pairs(GetValue(record, "TraitorPartners")) do
+				for partnerID, partnerTable in pairs(TotalStats.GetValue(record, "TraitorPartners")) do
 					thisPartnerWinRate = math.Round(partnerTable.Wins/partnerTable.Rounds*100, 1)
 					if thisPartnerWinRate > bestPartner.Winrate then
 						bestPartner.Winrate = thisPartnerWinRate
 						bestPartner.Nick = partnerTable.Nick
 					end
 				end
-				DataDisplay:AddLine(GetValue(record, "Nickname", "<UNKNOWN>"), bestPartner.Nick.." ("..bestPartner.Winrate.."%)")
+				DataDisplay:AddLine(TotalStats.GetValue(record, "Nickname", "<UNKNOWN>"), bestPartner.Nick.." ("..bestPartner.Winrate.."%)")
 			end
 
 		elseif str == "Favourite detective equipment" then
@@ -373,13 +362,13 @@ local function DisplayWindow()
 			for id, record in pairs(PlayerStats) do
 				local favouriteEquipment = "No equipment bought yet"
 				local mostTimesBought = 0
-				for itemName, thisItemTimesBought in pairs(GetValue(record, "DetectiveEquipment")) do
+				for itemName, thisItemTimesBought in pairs(TotalStats.GetValue(record, "DetectiveEquipment")) do
 					if thisItemTimesBought > mostTimesBought then
 						favouriteEquipment = itemName
 						mostTimesBought = thisItemTimesBought
 					end
 				end
-				DataDisplay:AddLine(GetValue(record, "Nickname", "<UNKNOWN>"), favouriteEquipment.." ("..mostTimesBought..")")
+				DataDisplay:AddLine(TotalStats.GetValue(record, "Nickname", "<UNKNOWN>"), favouriteEquipment.." ("..mostTimesBought..")")
 			end
 
 		elseif str == "Favourite traitor equipment" then
@@ -388,13 +377,13 @@ local function DisplayWindow()
 			for id, record in pairs(PlayerStats) do
 				local favouriteEquipment = "No equipment bought yet"
 				local mostTimesBought = 0
-				for itemName, thisItemTimesBought in pairs(GetValue(record, "TraitorEquipment")) do
+				for itemName, thisItemTimesBought in pairs(TotalStats.GetValue(record, "TraitorEquipment")) do
 					if thisItemTimesBought > mostTimesBought then
 						favouriteEquipment = itemName
 						mostTimesBought = thisItemTimesBought
 					end
 				end
-				DataDisplay:AddLine(GetValue(record, "Nickname", "<UNKNOWN>"), favouriteEquipment.." ("..mostTimesBought..")")
+				DataDisplay:AddLine(TotalStats.GetValue(record, "Nickname", "<UNKNOWN>"), favouriteEquipment.." ("..mostTimesBought..")")
 			end
 
 		end

--- a/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/cl_init.lua
+++ b/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/cl_init.lua
@@ -1,4 +1,4 @@
-include('shared.lua')
+include("shared.lua")
 
 local AccessButton = vgui.Create("DButton")
 AccessButton:SetText("Total Statistics")
@@ -118,20 +118,20 @@ local function DisplayWindow()
 			rolestring_cap = rolestring:sub(1, 1):upper() .. rolestring:sub(2)
 			if str == rolestring_cap then
 				for id, record in pairs(PlayerStats) do
-					DataDisplay:AddLine(record.Nickname, math.Round((record[rolestring..'Wins'] or 0)/(record[rolestring..'Rounds'] or 1)*100, 1))
+					DataDisplay:AddLine(record.Nickname, math.Round((record[rolestring.."Wins"] or 0)/(record[rolestring.."Rounds"] or 1)*100, 1))
 					DataDisplay:SortByColumn(2, true)
 				end
 			end
 		end
 	end
 	RoleDropdown:Hide()
-	
+
 	local YourStatsLabel = vgui.Create("DLabel", MainWindow)
 	YourStatsLabel:SetText("Subcategory:")
 	YourStatsLabel:SetPos(20, 65)
 	YourStatsLabel:SetSize(90, 25)
 	YourStatsLabel:Hide()
-	
+
 	local YourStatsDropdown = vgui.Create("DComboBox", MainWindow)
 	YourStatsDropdown:SetText("")
 	YourStatsDropdown:SetPos(110, 65)
@@ -159,12 +159,12 @@ local function DisplayWindow()
 						for r = 0, ROLE_MAX do
 							rolestring = ROLE_STRINGS[r]
 							rolestring_cap = rolestring:sub(1, 1):upper() .. rolestring:sub(2)
-							DataDisplay:AddLine(rolestring_cap, math.Round((record[rolestring..'Wins'] or 0)/(record[rolestring..'Rounds'] or 1)*100), 1)
+							DataDisplay:AddLine(rolestring_cap, math.Round((record[rolestring.."Wins"] or 0)/(record[rolestring.."Rounds"] or 1)*100), 1)
 						end
 					end
 				end
 			end
-		
+
 		elseif str == "Times played role" then
 		DescriptionLabel:SetText("Rounds playing each role (times role played/total rounds played).")
 			for id, record in pairs(PlayerStats) do
@@ -181,16 +181,16 @@ local function DisplayWindow()
 							for r = 3, ROLE_MAX do
 								rolestring = ROLE_STRINGS[r]
 								rolestring_cap = rolestring:sub(1, 1):upper() .. rolestring:sub(2)
-								DataDisplay:AddLine(rolestring_cap, (record[rolestring..'Rounds'] or 0).."/"..record.TotalRoundsPlayed)
+								DataDisplay:AddLine(rolestring_cap, (record[rolestring.."Rounds"] or 0).."/"..record.TotalRoundsPlayed)
 							end
 						end
 					end
 				end
 			end
-		
+
 		elseif str == "Best traitor partners" then
 			DescriptionLabel:SetText("Win rate when on a traitor team with each player (%).")
-			
+
 			if (PlayerStats[LocalPlayer():SteamID()]["TraitorPartners"]==nil) then
 				DataDisplay:AddLine("No partners yet", "No partners yet")
 			else
@@ -199,10 +199,10 @@ local function DisplayWindow()
 				end
 			end
 			DataDisplay:SortByColumn(2, true)
-			
+
 		elseif str == "Favourite detective equipment" then
 			DescriptionLabel:SetText("Times you've bought each detective item")
-			
+
 			if (PlayerStats[LocalPlayer():SteamID()]["DetectiveEquipment"]==nil) then
 				DataDisplay:AddLine("No equipment yet", "No equipment yet")
 			else
@@ -211,10 +211,10 @@ local function DisplayWindow()
 				end
 			end
 			DataDisplay:SortByColumn(2, true)
-		
+
 		elseif str == "Favourite traitor equipment" then
 			DescriptionLabel:SetText("Times you've bought each traitor item")
-			
+
 			if (PlayerStats[LocalPlayer():SteamID()]["TraitorEquipment"]==nil) then
 				DataDisplay:AddLine("No equipment yet", "No equipment yet")
 			else
@@ -223,12 +223,12 @@ local function DisplayWindow()
 				end
 			end
 			DataDisplay:SortByColumn(2, true)
-		
+
 		end
-		
+
 	end
 	YourStatsDropdown:Hide()
-	
+
 	local StatisticDropdown = vgui.Create("DComboBox", MainWindow)
 	StatisticDropdown:SetText("")
 	StatisticDropdown:SetPos(110, 35)
@@ -255,7 +255,7 @@ local function DisplayWindow()
 			DescriptionLabel:SetText("")
 			YourStatsDropdown:Show()
 			YourStatsLabel:Show()
-			
+
 		elseif str == "Server average role win rates" then
 			DescriptionLabel:SetText("Server-wide role average win rates (%).")
 			local AvgDRate = 0
@@ -272,7 +272,7 @@ local function DisplayWindow()
 			DataDisplay:AddLine("Detective", AvgDRate)
 			DataDisplay:AddLine("Innocent", AvgIRate)
 			DataDisplay:AddLine("Traitor", AvgTRate)
-			
+
 			if(CustomRolesEnabled) then
 				local AvgRate = {}
 				local sRolestring = ""
@@ -283,7 +283,7 @@ local function DisplayWindow()
 					AvgRate[sRolestring] = 0
 					for id, record in pairs(PlayerStats) do
 						AvgRate[sRolestring] = AvgRate[sRolestring] +
-								((record[rolestring..'Wins'] or 0)/(record[rolestring..'Rounds'] or 1)*100)
+								((record[rolestring.."Wins"] or 0)/(record[rolestring.."Rounds"] or 1)*100)
 					end
 					AvgRate[sRolestring] = math.Round(AvgRate[sRolestring] / table.Count(PlayerStats), 1)
 					DataDisplay:AddLine(rolestring_cap, AvgRate[sRolestring])
@@ -294,28 +294,28 @@ local function DisplayWindow()
 			DescriptionLabel:SetText("Average role win rate (%).")
 			RoleLabel:Show()
 			RoleDropdown:Show()
-		
+
 		elseif str == "Most rounds played" then
 			DescriptionLabel:SetText("Total number of rounds played.")
 			for id, record in pairs(PlayerStats) do
 				DataDisplay:AddLine(record.Nickname, record.TotalRoundsPlayed)
 				DataDisplay:SortByColumn(2, true)
 			end
-			
+
 		elseif str == "Most often killed first" then
 			DescriptionLabel:SetText("Percentage of their rounds that each player is killed first (%).")
 			for id, record in pairs(PlayerStats) do
 				DataDisplay:AddLine(record.Nickname, math.Round(record.KilledFirst / record.TotalRoundsPlayed * 100, 2))
 				DataDisplay:SortByColumn(2, true)
 			end
-			
+
 		elseif str == "Most crooked cop" then
 			DescriptionLabel:SetText("Average number of innocents killed per round as detective.")
 			for id, record in pairs(PlayerStats) do
 				DataDisplay:AddLine(record.Nickname, math.Round(record.CrookedCop/record.detectiveRounds, 2))
 				DataDisplay:SortByColumn(2, true)
 			end
-			
+
 		elseif str == "Most trigger-happy innocent" then
 			DescriptionLabel:SetText("Average number of innocent players killed while on the innocent team.")
 			for id, record in pairs(PlayerStats) do
@@ -323,17 +323,17 @@ local function DisplayWindow()
 				(record.innocentRounds + record.MercenaryRounds + record.GlitchRounds + record.PhantomRounds), 2))
 				DataDisplay:SortByColumn(2, true)
 			end
-		
+
 		elseif str == "Least safe near ledges" then
 			DescriptionLabel:SetText("Total fall damage taken.")
 			for id, record in pairs(PlayerStats) do
 				DataDisplay:AddLine(record.Nickname, record.TotalFallDamage)
 				DataDisplay:SortByColumn(2, true)
 			end
-		
+
 		elseif str == "Best traitor partners" then
 			DescriptionLabel:SetText("Each player's best traitor partner (win rate %).")
-			
+
 			for id, record in pairs(PlayerStats) do
 				local bestPartner = {Nick = "No traitor partners yet", Winrate = -1}
 				local thisPartnerWinRate = -1
@@ -346,10 +346,10 @@ local function DisplayWindow()
 				end
 				DataDisplay:AddLine(record.Nickname, bestPartner.Nick.." ("..bestPartner.Winrate.."%)")
 			end
-		
+
 		elseif str == "Favourite detective equipment" then
 			DescriptionLabel:SetText("Each player's favourite detective equipment (times bought).")
-			
+
 			for id, record in pairs(PlayerStats) do
 				local favouriteEquipment = "No equipment bought yet"
 				local mostTimesBought = 0
@@ -361,10 +361,10 @@ local function DisplayWindow()
 				end
 				DataDisplay:AddLine(record.Nickname, favouriteEquipment.." ("..mostTimesBought..")")
 			end
-		
+
 		elseif str == "Favourite traitor equipment" then
 			DescriptionLabel:SetText("Each player's favourite traitor equipment (times bought).")
-			
+
 			for id, record in pairs(PlayerStats) do
 				local favouriteEquipment = "No equipment bought yet"
 				local mostTimesBought = 0
@@ -379,7 +379,7 @@ local function DisplayWindow()
 
 		end
 	end
-	
+
 	gui.EnableScreenClicker(true)
 end
 
@@ -416,7 +416,7 @@ hook.Add("TTTBoughtItem", "TotalStatistics_PlayerBoughtItem", function(is_item, 
 			return
 		end
 	end
-	
+
 	--if its not on the SWEP list, then check the equipment item menu for the role
 	if LocalPlayer():GetRole() == ROLE_DETECTIVE then
 		for k, v in pairs (EquipmentItems[ROLE_DETECTIVE]) do
@@ -439,7 +439,7 @@ hook.Add("TTTBoughtItem", "TotalStatistics_PlayerBoughtItem", function(is_item, 
 			end
 		end
 	end
-	
+
 	--if we can't find it, let the server know
 	error = true
 	net.Start("TotalStatistics_SendClientEquipmentName")

--- a/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/init.lua
+++ b/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/init.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 
-include('shared.lua')
+include("shared.lua")
 
 --declare our variables for various shenanigans
 local PlayerStats = {}
@@ -31,14 +31,14 @@ local function LoadPlayerStats()
 	local data = file.Read("ttt/ttt_total_statistics/stats.txt", "DATA")
 	if data == "" then return end
 	PlayerStats = util.JSONToTable(data)
-	
+
 	--check if format is up to date and update it if not
 	local updated = false
 	for steamID, record in pairs(PlayerStats) do
-		if not PlayerStats[steamID]['Nickname'] then
+		if not PlayerStats[steamID]["Nickname"] then
 			for _ , ply in ipairs(player.GetAll()) do
 				if ply:SteamID() == steamID then
-					PlayerStats[steamID]['Nickname'] = ply:Nick()
+					PlayerStats[steamID]["Nickname"] = ply:Nick()
 				end
 			end
 		end
@@ -60,35 +60,35 @@ end
 local function AddNewPlayer(ID, nick)
 	PlayerStats[ID] = {}
 
-	PlayerStats[ID]['Nickname'] = nick
+	PlayerStats[ID]["Nickname"] = nick
 
 	local rolestring = ""
 	for r = 0, ROLE_MAX do
 		rolestring = ROLE_STRINGS[r]
-		PlayerStats[ID][rolestring..'Rounds'] = 0
-		PlayerStats[ID][rolestring..'Wins'] = 0
+		PlayerStats[ID][rolestring.."Rounds"] = 0
+		PlayerStats[ID][rolestring.."Wins"] = 0
 	end
 
-	local stats = {'CrookedCop', 'TriggerHappyInnocent', 'TotalFallDamage', 'KilledFirst', 'TotalRoundsPlayed'}
+	local stats = {"CrookedCop", "TriggerHappyInnocent", "TotalFallDamage", "KilledFirst", "TotalRoundsPlayed"}
 	for _, s in ipairs(stats) do
 		PlayerStats[ID][s] = 0
 	end
 
-	local statArray = {'TraitorPartners', 'DetectiveEquipment', 'TraitorEquipment'}
+	local statArray = {"TraitorPartners", "DetectiveEquipment", "TraitorEquipment"}
 	for _, a in ipairs(statArray) do
 		PlayerStats[ID][a] = {}
 	end
 end
 
 local function SavePlayerStats()
-	local str = util.TableToJSON(PlayerStats, true) 
+	local str = util.TableToJSON(PlayerStats, true)
 	file.Write("ttt/ttt_total_statistics/stats.txt", str)
 end
 
-local function ResetAllPlayerStats()
-	file.Delete("ttt/ttt_total_statistics/stats.txt")
-	LoadPlayerStats()
-end
+--local function ResetAllPlayerStats()
+--	file.Delete("ttt/ttt_total_statistics/stats.txt")
+--	LoadPlayerStats()
+--end
 
 concommand.Add("ttt_totalstatistics_reset", function(ply, cmd, args, str)
 	file.Delete("ttt/ttt_total_statistics/stats.txt")
@@ -128,9 +128,9 @@ hook.Add("TTTBeginRound", "TotalStatistics_StartOfRoundLogic", function()
 	table.Empty(StartingTraitors)
 	table.Empty(StartingRoles)
 	PreviousRoundDebug = ""
-	
-	CurrentPlayers = team.GetPlayers(TEAM_TERROR) 
-	
+
+	CurrentPlayers = team.GetPlayers(TEAM_TERROR)
+
 	--find traitors and their partners
 	--also stuck swapper spawn and starting zombie team capture on the end
 	for k, ply in pairs(CurrentPlayers) do
@@ -142,14 +142,14 @@ hook.Add("TTTBeginRound", "TotalStatistics_StartOfRoundLogic", function()
 			end
 		end
 	end
-	
+
 	PrintTable(StartingRoles)
 end)
 
 hook.Add("EntityTakeDamage", "TotalStatistics_FallDamageCapture", function(ply, dmginfo)
 	if(ply:IsPlayer() and dmginfo:IsFallDamage() and not ply:IsBot()) then
 		if dmginfo:GetDamage() > 100 then --cap the damage or you get +5000 for falling through the world
-			PlayerStats[ply:SteamID()].TotalFallDamage = PlayerStats[ply:SteamID()].TotalFallDamage + 100 
+			PlayerStats[ply:SteamID()].TotalFallDamage = PlayerStats[ply:SteamID()].TotalFallDamage + 100
 		else
 			PlayerStats[ply:SteamID()].TotalFallDamage = PlayerStats[ply:SteamID()].TotalFallDamage + math.Round(dmginfo:GetDamage())
 		end
@@ -162,19 +162,19 @@ hook.Add("DoPlayerDeath", "TotalStatistics_MurderCapture", function(victim, atta
 	(victim:IsPlayer() and (victim:IsInnocentTeam() or victim:IsJesterTeam()))) then
 		PlayerStats[attacker:SteamID()].CrookedCop = PlayerStats[attacker:SteamID()].CrookedCop + 1
 	end
-	
+
 	--trigger-happy innocent capture
 	if((attacker:IsPlayer() and (attacker:GetRole() == ROLE_INNOCENT
 			or (CR_VERSION and attacker:IsInnocentTeam())) and not attacker:IsBot()) and (victim:IsPlayer()
 			and (victim:GetRole() == ROLE_INNOCENT or (CR_VERSION and (victim:IsInnocentTeam() or victim:IsJesterTeam()))))) then
 		PlayerStats[attacker:SteamID()].TriggerHappyInnocent = PlayerStats[attacker:SteamID()].TriggerHappyInnocent + 1
 	end
-	
+
 	--swapper win logic
 	if(attacker:IsPlayer() and (victim:IsPlayer() and victim:GetRole()==ROLE_SWAPPER)) then
 		SwapperKilled = true
 	end
-	
+
 	--first killed capture
 	if victim:IsValid() and not victim:IsBot() and not FirstBeenKilled then
 		PlayerStats[victim:SteamID()].KilledFirst = PlayerStats[victim:SteamID()].KilledFirst + 1
@@ -183,7 +183,7 @@ hook.Add("DoPlayerDeath", "TotalStatistics_MurderCapture", function(victim, atta
 end)
 
 hook.Add("TTTEndRound", "TotalStatistics_EndOfRoundLogic", function(result)
-	
+
 	for k, v in pairs(CurrentPlayers) do
 
 		if(v:IsValid() and not v:IsBot()) then
@@ -198,11 +198,11 @@ hook.Add("TTTEndRound", "TotalStatistics_EndOfRoundLogic", function(result)
 				if StartingRoles[v:SteamID()] == r  then
 					FoundRole = true
 					rolestring = ROLE_STRINGS[r]
-					PlayerStats[v:SteamID()][rolestring..'Rounds'] = (PlayerStats[v:SteamID()][rolestring..'Rounds'] or 0) + 1
+					PlayerStats[v:SteamID()][rolestring.."Rounds"] = (PlayerStats[v:SteamID()][rolestring.."Rounds"] or 0) + 1
 					PreviousRoundDebug = PreviousRoundDebug ..rolestring.." and "
 					if r == ROLE_SWAPPER then
 						if(SwapperKilled) then
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						else
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
@@ -211,68 +211,68 @@ hook.Add("TTTEndRound", "TotalStatistics_EndOfRoundLogic", function(result)
 						if v:IsBeggar() then
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
 						else
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						end
 					elseif r == ROLE_BODYSNATCHER then
 						if v:IsBodysnatcher() then
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
 						else
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						end
 					elseif v:IsInnocentTeam() then
 						if result == WIN_INNOCENT or result == WIN_TIMELIMIT then
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						else
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
 						end
 					elseif v:IsTraitorTeam() then
 						if result == WIN_TRAITOR then
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						else
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
 						end
 					elseif v:IsJester() then
 						if result == WIN_JESTER then
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						else
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
 						end
 					elseif v:IsClown() then
 						if result == WIN_CLOWN then
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						else
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
 						end
 					elseif v:IsOldMan() then
 						if result == WIN_OLDMAN then
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						else
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
 						end
 					elseif v:IsKiller() then
 						if result == WIN_KILLER then
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						else
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
 						end
 					elseif v:IsZombie() and not v:IsTraitorTeam() and not v:IsMonsterTeam() then
 						if result == WIN_ZOMBIE then
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						else
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
 						end
 					elseif v:IsMonsterTeam() then
 						if result == WIN_MONSTER then
-							PlayerStats[v:SteamID()][rolestring..'Wins'] = (PlayerStats[v:SteamID()][rolestring..'Wins'] or 0) + 1
+							PlayerStats[v:SteamID()][rolestring.."Wins"] = (PlayerStats[v:SteamID()][rolestring.."Wins"] or 0) + 1
 							PreviousRoundDebug = PreviousRoundDebug .. "won. "
 						else
 							PreviousRoundDebug = PreviousRoundDebug .. "lost. "
@@ -290,23 +290,22 @@ hook.Add("TTTEndRound", "TotalStatistics_EndOfRoundLogic", function(result)
 			PreviousRoundDebug = PreviousRoundDebug .. "\n"
 		end
 	end
-	
-	for k1, player in ipairs(StartingTraitors) do
+
+	for k1, ply in ipairs(StartingTraitors) do
 		for k2, partner in ipairs(StartingTraitors) do
-			if(partner==player) then
-			else
-				if(PlayerStats[player:SteamID()]["TraitorPartners"][partner:SteamID()] == nil) then --if hasn't been paired before
-					PlayerStats[player:SteamID()]["TraitorPartners"][partner:SteamID()] = {Nick = partner:Nick(), Rounds = 0, Wins = 0}
+			if(partner~=ply) then
+				if(PlayerStats[ply:SteamID()]["TraitorPartners"][partner:SteamID()] == nil) then --if hasn't been paired before
+					PlayerStats[ply:SteamID()]["TraitorPartners"][partner:SteamID()] = {Nick = partner:Nick(), Rounds = 0, Wins = 0}
 				end
-				
-				PlayerStats[player:SteamID()]["TraitorPartners"][partner:SteamID()].Rounds = PlayerStats[player:SteamID()]["TraitorPartners"][partner:SteamID()].Rounds + 1
-				if(result==WIN_TRAITOR) then 
-					PlayerStats[player:SteamID()]["TraitorPartners"][partner:SteamID()].Wins = PlayerStats[player:SteamID()]["TraitorPartners"][partner:SteamID()].Wins + 1
+
+				PlayerStats[ply:SteamID()]["TraitorPartners"][partner:SteamID()].Rounds = PlayerStats[ply:SteamID()]["TraitorPartners"][partner:SteamID()].Rounds + 1
+				if(result==WIN_TRAITOR) then
+					PlayerStats[ply:SteamID()]["TraitorPartners"][partner:SteamID()].Wins = PlayerStats[ply:SteamID()]["TraitorPartners"][partner:SteamID()].Wins + 1
 				end
 			end
 		end
 	end
-	
+
 	SavePlayerStats()
 end)
 
@@ -373,8 +372,11 @@ net.Receive("TotalStatistics_SendClientEquipmentName", function(len, ply)
 	local error = net.ReadBool()
 	if error then
 		print("Failed to find equipment ("..name..") bought by "..ply:Nick().." for [TTT] Total Statistics!")
-	elseif ply:IsBot() then
-	elseif ply:GetRole()==ROLE_DETECTIVE then
+        return
+    end
+	if ply:IsBot() then return end
+
+	if ply:GetRole()==ROLE_DETECTIVE then
 		if(PlayerStats[ply:SteamID()]["DetectiveEquipment"][name] == nil) then --if hasn't been paired before
 			PlayerStats[ply:SteamID()]["DetectiveEquipment"][name] = 0
 		end

--- a/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/init.lua
+++ b/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/init.lua
@@ -313,72 +313,72 @@ end)
 util.AddNetworkString("TotalStatistics_PlayerStatsMessage")
 util.AddNetworkString("TotalStatistics_RequestPlayerStats")
 net.Receive("TotalStatistics_RequestPlayerStats", function(_, ply)
-    local playerStatsJson = util.TableToJSON(PlayerStats)
-    local compressedString = util.Compress(playerStatsJson)
-    local len = #compressedString
+	local playerStatsJson = util.TableToJSON(PlayerStats)
+	local compressedString = util.Compress(playerStatsJson)
+	local len = #compressedString
 
 	net.Start("TotalStatistics_PlayerStatsMessage")
-    net.WriteUInt(len, 16)
-    net.WriteData(compressedString, len)
+	net.WriteUInt(len, 16)
+	net.WriteData(compressedString, len)
 	net.Send(ply)
 end)
 
 local function RenameWeps(name)
-    if name == "sipistol_name" then
-        return "Silenced Pistol"
-    elseif name == "knife_name" then
-        return "Knife"
-    elseif name == "newton_name" then
-        return "Newton Launcher"
-    elseif name == "tele_name" then
-        return "Teleporter"
-    elseif name == "hstation_name" then
-        return "Health Station"
-    elseif name == "flare_name" then
-        return "Flare Gun"
-    elseif name == "decoy_name" then
-        return "Decoy"
-    elseif name == "radio_name" then
-        return "Radio"
-    elseif name == "polter_name" then
-        return "Poltergeist"
-    elseif name == "vis_name" then
-        return "Visualizer"
-    elseif name == "defuser_name" then
-        return "Defuser"
-    elseif name == "stungun_name" then
-        return "UMP Prototype"
-    elseif name == "binoc_name" then
-        return "Binoculars"
+	if name == "sipistol_name" then
+		return "Silenced Pistol"
+	elseif name == "knife_name" then
+		return "Knife"
+	elseif name == "newton_name" then
+		return "Newton Launcher"
+	elseif name == "tele_name" then
+		return "Teleporter"
+	elseif name == "hstation_name" then
+		return "Health Station"
+	elseif name == "flare_name" then
+		return "Flare Gun"
+	elseif name == "decoy_name" then
+		return "Decoy"
+	elseif name == "radio_name" then
+		return "Radio"
+	elseif name == "polter_name" then
+		return "Poltergeist"
+	elseif name == "vis_name" then
+		return "Visualizer"
+	elseif name == "defuser_name" then
+		return "Defuser"
+	elseif name == "stungun_name" then
+		return "UMP Prototype"
+	elseif name == "binoc_name" then
+		return "Binoculars"
 	elseif name == "item_radar" then
-        return "Radar"
+		return "Radar"
 	elseif name == "item_armor" then
-        return "Body Armor"
+		return "Body Armor"
 	elseif name == "dragon_elites_name" then
-        return "Dragon Elites"
+		return "Dragon Elites"
 	elseif name == "silenced_m4a1_name" then
-        return "Silenced M4A1"
+		return "Silenced M4A1"
 	elseif name == "slam_name" then
-        return "M4 SLAM"
+		return "M4 SLAM"
 	elseif name == "jihad_bomb_name" then
-        return "Jihad Bomb"
-    elseif name == "item_slashercloak" then --custom mods friends and I made ;)
+		return "Jihad Bomb"
+	elseif name == "item_slashercloak" then --custom mods friends and I made ;)
 		return "Slasher Cloak"
 	elseif name == "heartbeat_monitor_name" then
 		return "Heartbeat Monitor"
-	else
-        return name
-    end
+	end
+	return name
 end
 
 --recive the client name for the equipment they bought
 net.Receive("TotalStatistics_SendClientEquipmentName", function(len, ply)
-    local name = RenameWeps(net.ReadString())
+	local originalName = net.ReadString()
+	local name = RenameWeps(originalName)
 	local error = net.ReadBool()
-	if error then
-		print("Failed to find equipment ("..name..") bought by "..ply:Nick().." for [TTT] Total Statistics!")
-        return
-    end
+	if error and originalName == name then
+		print("Failed to find equipment ("..originalName..") bought by "..ply:Nick().." for [TTT] Total Statistics!")
+		return
+	end
 	if ply:IsBot() then return end
 
 	if ply:GetRole()==ROLE_DETECTIVE then

--- a/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/init.lua
+++ b/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/init.lua
@@ -312,9 +312,14 @@ end)
 --recieve data request from client and table back
 util.AddNetworkString("TotalStatistics_PlayerStatsMessage")
 util.AddNetworkString("TotalStatistics_RequestPlayerStats")
-net.Receive("TotalStatistics_RequestPlayerStats", function(len, ply)
+net.Receive("TotalStatistics_RequestPlayerStats", function(_, ply)
+    local playerStatsJson = util.TableToJSON(PlayerStats)
+    local compressedString = util.Compress(playerStatsJson)
+    local len = #compressedString
+
 	net.Start("TotalStatistics_PlayerStatsMessage")
-	net.WriteTable(PlayerStats)
+    net.WriteUInt(len, 16)
+    net.WriteData(compressedString, len)
 	net.Send(ply)
 end)
 

--- a/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/shared.lua
+++ b/TTT_Total_Statistics_CR/gamemodes/terrortown/entities/entities/ttt_total_statistics/shared.lua
@@ -1,2 +1,24 @@
 ENT.Type = "point"
 ENT.Base = "base_point"
+
+TotalStats = {}
+
+local StringCapitalize = string.Capitalize
+local StringLower = string.lower
+local StringSub = string.sub
+
+local function LowerFirst(str)
+	return StringLower(StringSub(str, 1, 1)) .. StringSub(str, 2)
+end
+
+function TotalStats.GetRecordNames(name)
+	local lower = LowerFirst(name)
+	local upper = StringCapitalize(name)
+	return upper, lower
+end
+
+function TotalStats.GetValue(record, name, default)
+	if not default then default = 0 end
+	local upper, lower = TotalStats.GetRecordNames(name)
+	return record[upper] or record[lower] or default
+end


### PR DESCRIPTION
- Added logic to convert old lowerKeys to new upperKeys and merge values
- Added ttt_totalstatistics_remove_byid
- Added ttt_totalstatistics_remove_byname
- Changed statistics to send as a compressed string to save space
- Changed stat lookups to be backwards compatible with old casing, preferring new if available
- Changed shop equipment handling to support custom shop items better
- Fixed some stats coming through as "nan" when a player hadn't played as a specific role